### PR TITLE
feat: 스레드 뷰에서 바로 삭제

### DIFF
--- a/app/components/CommitThread.tsx
+++ b/app/components/CommitThread.tsx
@@ -4,7 +4,10 @@ import { useMemo, useState } from 'react'
 import { Link } from 'react-transition-progress/next'
 import { CommitSchema } from '@/db/schema'
 import { CommitFormReply } from '../commit/components/CommitFormReply'
+import { useCommitWriter } from '../commit/components/CommitForm.hooks'
+import { tombstoneRevision } from '@/lib/revision'
 import { CommitItem } from './CommitItem'
+import { CommitView } from './CommitList.types'
 import { buildThreads, mergeOutbox } from './CommitList.utils'
 import { useOutbox, useOutboxPrune } from './Outbox.hooks'
 
@@ -18,8 +21,24 @@ type CommitThreadProps = {
 export function CommitThread({ list, rootNoteId, userId }: CommitThreadProps) {
   const outbox = useOutbox()
   const [targetNoteId, setTargetNoteId] = useState(rootNoteId)
+  const { write, isPending } = useCommitWriter()
 
   useOutboxPrune(list)
+
+  /**
+   * 삭제도 리비전을 하나 더 쌓는 것이다(톰스톤). 뿌리를 지우면 스레드가
+   * 통째로 사라지므로 목록으로 돌아가고, 답글이면 스레드에 머문다.
+   */
+  function handleDelete(item: CommitView) {
+    if (!window.confirm('이 메모를 삭제할까요?')) {
+      return
+    }
+
+    write(
+      () => tombstoneRevision({ user_id: userId, current: item }),
+      item.reply_to_note_id ? `/commit/${rootNoteId}` : '/'
+    )
+  }
 
   const thread = useMemo(
     () =>
@@ -76,6 +95,17 @@ export function CommitThread({ list, rootNoteId, userId }: CommitThreadProps) {
                   >
                     이력
                   </Link>
+                  {/* 파괴적인 동작이라 가장 오른쪽 — 제일 자주 쓰는
+                      "이어쓰기"에서 멀리 둔다. 평소엔 다른 항목과 같은
+                      색이고 hover 때만 빨갛게 해 오탭을 줄인다. */}
+                  <button
+                    type="button"
+                    disabled={isPending}
+                    className="hover:text-red-400 disabled:opacity-50"
+                    onClick={() => handleDelete(item)}
+                  >
+                    삭제
+                  </button>
                 </div>
               )
             }


### PR DESCRIPTION
삭제 기능 자체는 이미 있었습니다(`tombstoneRevision`). 다만 **수정 화면
(`/commit/[id]/amend`) 안에만** 있어서 찾기 어려웠습니다. 스레드 뷰 액션 줄에 노출합니다.

액션 줄이 `이어쓰기 / 수정 / 이력` 에서 `이어쓰기 / 수정 / 이력 / 삭제` 가 됩니다.

## 동작

- 삭제는 여전히 **톰스톤 리비전**입니다. 행을 지우지 않으므로 오프라인에서 지운 메모가
  동기화 때 되살아나지 않고, 이력 화면에도 "삭제함" 으로 남습니다
- 뿌리를 지우면 스레드가 통째로 사라지므로 목록으로, 답글이면 스레드에 머뭅니다
  (`CommitFormEdit` 과 같은 규칙)
- `window.confirm` 확인은 그대로입니다

## 배치

파괴적인 동작이라 **가장 오른쪽**에 뒀습니다 — 제일 자주 쓰는 "이어쓰기" 에서 멀리
떨어뜨렸습니다. 평소엔 다른 항목과 같은 색이고 **hover 때만 빨갛게** 해서, 평소 화면에는
노이즈를 더하지 않으면서 누를 때는 성격이 드러나게 했습니다.
(`red` 는 `OutboxSync`/`ErrorMessage` 에서 이미 쓰는 색이라 새 어휘가 아닙니다.)

수정 화면의 삭제 버튼은 그대로 뒀습니다. 편집 중에 지우는 것도 자연스러운 경로입니다.

## 검증

빌드·타입체크·린트 통과. 톰스톤 자체의 동작(목록에서 사라짐, 뿌리 삭제 시 스레드 통째로
숨김)은 스레드 작업 때 검증된 것을 그대로 씁니다.

**로그인이 필요한 경로라 실제 클릭은 확인하지 못했습니다.** 브라우저에서 한 번
눌러봐 주시겠습니까?

🤖 Generated with [Claude Code](https://claude.com/claude-code)