### PR TITLE
refactor: Effect 실행 경계 일원화와 입력 검증 정리

### DIFF
--- a/app/account/_components/FormUser.actions.ts
+++ b/app/account/_components/FormUser.actions.ts
@@ -1,25 +1,52 @@
 'use server'
 
-import { UserService } from '@/services/User'
 import { Effect } from 'effect'
 import { revalidatePath } from 'next/cache'
+import { UserService } from '@/services/User'
+import { NextAuthService } from '@/services/NextAuth'
+import { runEffect } from '@/runtime/run'
+import {
+  getInitialActionState,
+  InitialActionState,
+} from '@/helpers/getInitialActionState'
+import { toMessage } from '@/helpers/getMessage'
 
-export async function updateUser(_: unknown, formData: FormData) {
-  return Effect.gen(function* () {
-    const userService = yield* UserService
-    const id = formData.get('id') as string
+/**
+ * 고칠 대상은 세션의 사용자다. 폼이 보낸 `id` 를 그대로 쓰면 값을 바꿔
+ * 남의 계정을 고칠 수 있다.
+ *
+ * 실패는 폼에 돌려준다. 조용히 삼키면 저장된 것처럼 보인다.
+ */
+export async function updateUser(
+  _: unknown,
+  formData: FormData
+): Promise<InitialActionState> {
+  const name = String(formData.get('name') ?? '').trim()
 
-    yield* userService.updateUser(id, {
-      name: formData.get('name') as string,
-    })
-  }).pipe(
-    Effect.provide(UserService.Default),
-    Effect.match({
-      onSuccess: () => {
-        revalidatePath('/account')
-      },
-      onFailure: () => Effect.void,
-    }),
-    Effect.runPromise
+  if (name.length === 0) {
+    return { data: null, errors: [toMessage('이름을 입력해주세요.')] }
+  }
+
+  return runEffect(
+    Effect.gen(function* () {
+      const userService = yield* UserService
+      const nextAuthService = yield* NextAuthService
+
+      const id = yield* nextAuthService.getUserId()
+
+      yield* userService.updateUser(id, { name })
+    }).pipe(
+      Effect.tapErrorCause(Effect.logError),
+      Effect.match({
+        onSuccess(): InitialActionState {
+          revalidatePath('/account')
+
+          return getInitialActionState()
+        },
+        onFailure(): InitialActionState {
+          return { data: null, errors: [toMessage('저장하지 못했습니다.')] }
+        },
+      })
+    )
   )
 }

--- a/app/account/_components/FormUser.tsx
+++ b/app/account/_components/FormUser.tsx
@@ -3,6 +3,8 @@ import { User } from 'next-auth'
 import Image from 'next/image'
 import { ComponentProps, useActionState } from 'react'
 import { updateUser } from './FormUser.actions'
+import { getInitialActionState } from '@/helpers/getInitialActionState'
+import { ErrorMessage } from '@/app/components/ErrorMessage'
 
 type SessionUserDataProps = {
   data: User
@@ -19,15 +21,16 @@ function FormUserInput(props: ComponentProps<'input'>) {
 }
 
 export function FormUser({ data }: SessionUserDataProps) {
-  const [, formAction, isPending] = useActionState(updateUser, undefined)
+  const [state, formAction, isPending] = useActionState(
+    updateUser,
+    getInitialActionState()
+  )
 
   return Option.fromNullable(data).pipe(
     Option.match({
       onNone: () => null,
       onSome: (data) => (
         <form action={formAction} className="flex flex-col gap-4 self-start">
-          <input type="hidden" name="id" defaultValue={data.id} />
-
           {data.image && (
             <Image
               src={data.image}
@@ -58,6 +61,8 @@ export function FormUser({ data }: SessionUserDataProps) {
               />
             </FormUserField>
           </div>
+
+          <ErrorMessage errors={state.errors} />
 
           <button
             type="submit"

--- a/app/commit/[id]/_components/CommitNotFound.tsx
+++ b/app/commit/[id]/_components/CommitNotFound.tsx
@@ -1,0 +1,3 @@
+export function CommitNotFound() {
+  return <p className="p-4 text-gray-400">메모를 찾을 수 없습니다.</p>
+}

--- a/app/commit/[id]/amend/page.tsx
+++ b/app/commit/[id]/amend/page.tsx
@@ -1,68 +1,38 @@
-import { Effect, pipe } from 'effect'
-import { CommitService, NotFoundError } from '@/services/Commit'
+import { Effect } from 'effect'
+import { CommitService } from '@/services/Commit'
 import { NextAuthService } from '@/services/NextAuth'
 import { CommitFormEdit } from '../../components/CommitFormEdit'
-import { isUuid } from '@/lib/uuid'
-import {
-  CommitDetailParamsProps,
-  CommitDetailProps,
-  CommitDetailQueryProps,
-} from '../types'
+import { renderEffect } from '@/runtime/render'
+import { getNoteId } from '../params'
+import { CommitDetailProps, CommitDetailQueryProps } from '../types'
+import { CommitNotFound } from '../_components/CommitNotFound'
 
-async function CommitAmendQuery({ params, children }: CommitDetailQueryProps) {
-  return Effect.gen(function* () {
-    const commitService = yield* CommitService
-    const nextAuthService = yield* NextAuthService
+function CommitAmendQuery({ params, children }: CommitDetailQueryProps) {
+  return renderEffect(
+    Effect.gen(function* () {
+      const commitService = yield* CommitService
+      const nextAuthService = yield* NextAuthService
 
-    const userId = yield* nextAuthService.getUserId()
-    const data = yield* commitService.getItemByNoteId({
-      user_id: userId,
-      note_id: params.note_id,
-    })
+      const userId = yield* nextAuthService.getUserId()
+      const data = yield* commitService.getItemByNoteId({
+        user_id: userId,
+        note_id: params.note_id,
+      })
 
-    return { data, userId }
-  }).pipe(
-    Effect.provide(NextAuthService.Default),
-    Effect.provide(CommitService.Default),
-    Effect.match({
-      onSuccess: (result) => <>{children(result)}</>,
-      onFailure: (error) => (
-        <p className="p-4 text-gray-400" title={error._tag}>
-          메모를 찾을 수 없습니다.
-        </p>
-      ),
+      return { data, userId }
     }),
-    Effect.runPromise
-  )
-}
-
-function CommitAmendParams({ params, children }: CommitDetailParamsProps) {
-  return pipe(
-    Effect.promise(() => params),
-    Effect.flatMap(({ id }) =>
-      isUuid(id)
-        ? Effect.succeed(id)
-        : Effect.fail(new NotFoundError({ message: '잘못된 주소입니다.' }))
-    ),
-    Effect.match({
-      onSuccess: (note_id) => <>{children({ note_id })}</>,
-      onFailure: (error) => <pre title={error._tag}>{error.message}</pre>,
-    }),
-    Effect.runPromise
+    (result) => <>{children(result)}</>,
+    <CommitNotFound />
   )
 }
 
 async function CommitAmend({ params }: CommitDetailProps) {
+  const { note_id } = await getNoteId(params)
+
   return (
-    <CommitAmendParams params={params}>
-      {({ note_id }) => (
-        <CommitAmendQuery params={{ note_id }}>
-          {({ data, userId }) => (
-            <CommitFormEdit userId={userId} current={data} />
-          )}
-        </CommitAmendQuery>
-      )}
-    </CommitAmendParams>
+    <CommitAmendQuery params={{ note_id }}>
+      {({ data, userId }) => <CommitFormEdit userId={userId} current={data} />}
+    </CommitAmendQuery>
   )
 }
 

--- a/app/commit/[id]/history/page.tsx
+++ b/app/commit/[id]/history/page.tsx
@@ -1,70 +1,44 @@
-import { Effect, pipe } from 'effect'
+import { Effect } from 'effect'
+import { ReactNode } from 'react'
 import { CommitSchema } from '@/db/schema'
-import { CommitService, NotFoundError } from '@/services/Commit'
+import { CommitService } from '@/services/Commit'
 import { NextAuthService } from '@/services/NextAuth'
 import { CommitHistory } from '@/app/components/CommitHistory'
-import { isUuid } from '@/lib/uuid'
-import { CommitDetailParamsProps, CommitDetailProps, NoteId } from '../types'
+import { renderEffect } from '@/runtime/render'
+import { getNoteId } from '../params'
+import { CommitDetailProps, NoteId } from '../types'
+import { CommitNotFound } from '../_components/CommitNotFound'
 
 type CommitHistoryQueryProps = {
   params: NoteId
-  children: (revisions: CommitSchema[]) => React.ReactNode
+  children: (revisions: CommitSchema[]) => ReactNode
 }
 
-async function CommitHistoryQuery({
-  params,
-  children,
-}: CommitHistoryQueryProps) {
-  return Effect.gen(function* () {
-    const commitService = yield* CommitService
-    const nextAuthService = yield* NextAuthService
+function CommitHistoryQuery({ params, children }: CommitHistoryQueryProps) {
+  return renderEffect(
+    Effect.gen(function* () {
+      const commitService = yield* CommitService
+      const nextAuthService = yield* NextAuthService
 
-    const userId = yield* nextAuthService.getUserId()
+      const userId = yield* nextAuthService.getUserId()
 
-    return yield* commitService.getHistory({
-      user_id: userId,
-      note_id: params.note_id,
-    })
-  }).pipe(
-    Effect.provide(NextAuthService.Default),
-    Effect.provide(CommitService.Default),
-    Effect.match({
-      onSuccess: (revisions) => <>{children(revisions)}</>,
-      onFailure: (error) => (
-        <p className="p-4 text-gray-400" title={error._tag}>
-          메모를 찾을 수 없습니다.
-        </p>
-      ),
+      return yield* commitService.getHistory({
+        user_id: userId,
+        note_id: params.note_id,
+      })
     }),
-    Effect.runPromise
-  )
-}
-
-function CommitHistoryParams({ params, children }: CommitDetailParamsProps) {
-  return pipe(
-    Effect.promise(() => params),
-    Effect.flatMap(({ id }) =>
-      isUuid(id)
-        ? Effect.succeed(id)
-        : Effect.fail(new NotFoundError({ message: '잘못된 주소입니다.' }))
-    ),
-    Effect.match({
-      onSuccess: (note_id) => <>{children({ note_id })}</>,
-      onFailure: (error) => <pre title={error._tag}>{error.message}</pre>,
-    }),
-    Effect.runPromise
+    (revisions) => <>{children(revisions)}</>,
+    <CommitNotFound />
   )
 }
 
 async function CommitHistoryPage({ params }: CommitDetailProps) {
+  const { note_id } = await getNoteId(params)
+
   return (
-    <CommitHistoryParams params={params}>
-      {({ note_id }) => (
-        <CommitHistoryQuery params={{ note_id }}>
-          {(revisions) => <CommitHistory revisions={revisions} />}
-        </CommitHistoryQuery>
-      )}
-    </CommitHistoryParams>
+    <CommitHistoryQuery params={{ note_id }}>
+      {(revisions) => <CommitHistory revisions={revisions} />}
+    </CommitHistoryQuery>
   )
 }
 

--- a/app/commit/[id]/page.tsx
+++ b/app/commit/[id]/page.tsx
@@ -1,80 +1,48 @@
-import { Effect, pipe } from 'effect'
-import { CommitService, NotFoundError } from '@/services/Commit'
+import { Effect } from 'effect'
+import { CommitService } from '@/services/Commit'
 import { NextAuthService } from '@/services/NextAuth'
 import { CommitThread } from '@/app/components/CommitThread'
-import { isUuid } from '@/lib/uuid'
-import {
-  CommitDetailParamsProps,
-  CommitDetailProps,
-  CommitThreadQueryProps,
-} from './types'
+import { renderEffect } from '@/runtime/render'
+import { getNoteId } from './params'
+import { CommitDetailProps, CommitThreadQueryProps } from './types'
+import { CommitNotFound } from './_components/CommitNotFound'
 
 /**
  * 메모를 열었을 때 나와야 하는 것은 수정 폼이 아니라 그 메모와 거기서 자란
  * 것들이다. 답글을 열어도 뿌리부터 스레드 전체를 보여준다.
  */
-async function CommitThreadQuery({ params, children }: CommitThreadQueryProps) {
-  return Effect.gen(function* () {
-    const commitService = yield* CommitService
-    const nextAuthService = yield* NextAuthService
+function CommitThreadQuery({ params, children }: CommitThreadQueryProps) {
+  return renderEffect(
+    Effect.gen(function* () {
+      const commitService = yield* CommitService
+      const nextAuthService = yield* NextAuthService
 
-    const userId = yield* nextAuthService.getUserId()
-    const item = yield* commitService.getItemByNoteId({
-      user_id: userId,
-      note_id: params.note_id,
-    })
-    const thread = yield* commitService.getThread({
-      user_id: userId,
-      root_note_id: item.root_note_id,
-    })
+      const userId = yield* nextAuthService.getUserId()
+      const item = yield* commitService.getItemByNoteId({
+        user_id: userId,
+        note_id: params.note_id,
+      })
+      const thread = yield* commitService.getThread({
+        user_id: userId,
+        root_note_id: item.root_note_id,
+      })
 
-    return { thread, rootNoteId: item.root_note_id, userId }
-  }).pipe(
-    Effect.provide(NextAuthService.Default),
-    Effect.provide(CommitService.Default),
-    Effect.match({
-      onSuccess: (result) => <>{children(result)}</>,
-      onFailure: (error) => (
-        <p className="p-4 text-gray-400" title={error._tag}>
-          메모를 찾을 수 없습니다.
-        </p>
-      ),
+      return { thread, rootNoteId: item.root_note_id, userId }
     }),
-    Effect.runPromise
-  )
-}
-
-function CommitDetailParams({ params, children }: CommitDetailParamsProps) {
-  return pipe(
-    Effect.promise(() => params),
-    Effect.flatMap(({ id }) =>
-      isUuid(id)
-        ? Effect.succeed(id)
-        : Effect.fail(new NotFoundError({ message: '잘못된 주소입니다.' }))
-    ),
-    Effect.match({
-      onSuccess: (note_id) => <>{children({ note_id })}</>,
-      onFailure: (error) => <pre title={error._tag}>{error.message}</pre>,
-    }),
-    Effect.runPromise
+    (result) => <>{children(result)}</>,
+    <CommitNotFound />
   )
 }
 
 async function CommitDetail({ params }: CommitDetailProps) {
+  const { note_id } = await getNoteId(params)
+
   return (
-    <CommitDetailParams params={params}>
-      {({ note_id }) => (
-        <CommitThreadQuery params={{ note_id }}>
-          {({ thread, rootNoteId, userId }) => (
-            <CommitThread
-              list={thread}
-              rootNoteId={rootNoteId}
-              userId={userId}
-            />
-          )}
-        </CommitThreadQuery>
+    <CommitThreadQuery params={{ note_id }}>
+      {({ thread, rootNoteId, userId }) => (
+        <CommitThread list={thread} rootNoteId={rootNoteId} userId={userId} />
       )}
-    </CommitDetailParams>
+    </CommitThreadQuery>
   )
 }
 

--- a/app/commit/[id]/params.ts
+++ b/app/commit/[id]/params.ts
@@ -1,0 +1,19 @@
+import { notFound } from 'next/navigation'
+import { isUuid } from '@/lib/uuid'
+import { CommitDetailProps, NoteId } from './types'
+
+/**
+ * 세 화면(스레드/수정/이력)이 같은 주소 규칙을 쓴다. UUID 가 아니면 조회를
+ * 시도하지 않고 404 로 답한다.
+ */
+export async function getNoteId(
+  params: CommitDetailProps['params']
+): Promise<NoteId> {
+  const { id } = await params
+
+  if (!isUuid(id)) {
+    notFound()
+  }
+
+  return { note_id: id }
+}

--- a/app/commit/[id]/types.ts
+++ b/app/commit/[id]/types.ts
@@ -7,15 +7,6 @@ export type CommitDetailProps = { params: Promise<CommitDetailParams> }
 
 export type NoteId = Pick<CommitSchema, 'note_id'>
 
-/**
- * 렌더 프롭은 동기적으로 JSX 를 돌려준다. React 19 의 `FC` 는 반환형에
- * `Promise<ReactNode>` 를 포함해서 Fragment 안에 넣을 수 없다.
- */
-export type CommitDetailParamsProps = {
-  params: CommitDetailProps['params']
-  children: (params: NoteId) => ReactNode
-}
-
 export type CommitDetailQueryProps = {
   params: NoteId
   children: (result: { data: CommitSchema; userId: string }) => ReactNode

--- a/app/commit/actions.ts
+++ b/app/commit/actions.ts
@@ -2,6 +2,7 @@
 
 import { revalidatePath } from 'next/cache'
 import { Effect } from 'effect'
+import { runEffect } from '@/runtime/run'
 import { CommitService, PushRejection } from '@/services/Commit'
 import { CommitSchemaService } from '@/services/CommitSchemaService'
 import { NextAuthService } from '@/services/NextAuth'
@@ -18,7 +19,7 @@ export type PushResult =
  * 신뢰하면 타인 명의로 메모를 만들 수 있다.
  */
 export async function pushCommitsAction(payload: unknown): Promise<PushResult> {
-  return Effect.runPromise(
+  return runEffect(
     Effect.gen(function* () {
       const commitService = yield* CommitService
       const commitSchemaService = yield* CommitSchemaService
@@ -29,9 +30,7 @@ export async function pushCommitsAction(payload: unknown): Promise<PushResult> {
 
       return yield* commitService.push({ user_id, records })
     }).pipe(
-      Effect.provide(NextAuthService.Default),
-      Effect.provide(CommitService.Default),
-      Effect.provide(CommitSchemaService.Default),
+      Effect.tapErrorCause(Effect.logError),
       Effect.match({
         onSuccess({ accepted, rejected }): PushResult {
           if (accepted.length > 0) {

--- a/app/components/CommitList.server.tsx
+++ b/app/components/CommitList.server.tsx
@@ -5,6 +5,7 @@ import { Params } from '../types'
 import { Effect } from 'effect'
 import { CommitService } from '@/services/Commit'
 import { NextAuthService } from '@/services/NextAuth'
+import { renderEffect } from '@/runtime/render'
 import { getServerTimezone } from '@/lib/timezone'
 
 export type CommitListServerProps = {
@@ -24,28 +25,18 @@ export async function CommitListServer({
     formatStr: 'yyyy-MM',
   })
 
-  return (
-    <>
-      {Effect.gen(function* () {
-        const commitService = yield* CommitService
-        const nextAuthService = yield* NextAuthService
+  return renderEffect(
+    Effect.gen(function* () {
+      const commitService = yield* CommitService
+      const nextAuthService = yield* NextAuthService
 
-        const userId = yield* nextAuthService.getUserId()
-        const results = yield* commitService.getList({
-          user_id: userId,
-          ...getMonthRange(params.date ?? fallbackDate, timezone),
-        })
+      const userId = yield* nextAuthService.getUserId()
 
-        return results
-      }).pipe(
-        Effect.provide(NextAuthService.Default),
-        Effect.provide(CommitService.Default),
-        Effect.match({
-          onSuccess: (data) => <>{children(data)}</>,
-          onFailure: (e) => <pre>{e._tag}</pre>,
-        }),
-        Effect.runPromise
-      )}
-    </>
+      return yield* commitService.getList({
+        user_id: userId,
+        ...getMonthRange(params.date ?? fallbackDate, timezone),
+      })
+    }),
+    (data) => <>{children(data)}</>
   )
 }

--- a/app/components/Session.tsx
+++ b/app/components/Session.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from 'react'
 import { Session as NextAuthSession } from 'next-auth'
 import { Effect } from 'effect'
 import { NextAuthService } from '@/services/NextAuth'
+import { renderEffect } from '@/runtime/render'
 import { SessionFallback } from './SessionFallback'
 
 export type SessionReturn = NextAuthSession | null
@@ -11,29 +12,16 @@ export type SessionProps = {
 }
 
 export function Session({ children }: SessionProps) {
-  return (
-    <>
-      {Effect.gen(function* () {
-        const nextAuthService = yield* NextAuthService
-        const session = yield* nextAuthService.getSession()
+  return renderEffect(
+    Effect.gen(function* () {
+      const nextAuthService = yield* NextAuthService
 
-        return session
-      }).pipe(
-        Effect.provide(NextAuthService.Default),
-        Effect.match({
-          onSuccess(session) {
-            return <>{children(session)}</>
-          },
-          onFailure(error) {
-            return (
-              <div className="p-4">
-                <SessionFallback data-error={JSON.stringify(error, null, 2)} />
-              </div>
-            )
-          },
-        }),
-        Effect.runPromise
-      )}
-    </>
+      return yield* nextAuthService.getSession()
+    }),
+    (session) => <>{children(session)}</>,
+    // 로그인 전에는 실패가 정상이다. 오류 내용을 DOM 속성으로 흘리지 않는다.
+    <div className="p-4">
+      <SessionFallback />
+    </div>
   )
 }

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,16 @@
+import Link from 'next/link'
+
+export default function NotFound() {
+  return (
+    <div className="flex flex-col gap-2 p-4">
+      <h2 className="font-medium">찾을 수 없는 페이지입니다.</h2>
+      <p className="text-sm text-gray-400">
+        주소를 확인하거나{' '}
+        <Link href="/" className="underline">
+          홈
+        </Link>
+        으로 돌아가세요.
+      </p>
+    </div>
+  )
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -3,6 +3,7 @@ import GitHub from 'next-auth/providers/github'
 import { userInsertSchema } from '@/db/schema'
 import { Effect } from 'effect'
 import { UserService } from '@/services/User'
+import { runEffect } from '@/runtime/run'
 
 export const { handlers, signIn, signOut, auth } = NextAuth({
   providers: [GitHub],
@@ -32,7 +33,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           )
 
         return true
-      }).pipe(Effect.provide(UserService.Default), Effect.runPromise)
+      }).pipe(runEffect)
     },
     async session({ session }) {
       return await Effect.gen(function* () {
@@ -49,7 +50,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         )
 
         return session
-      }).pipe(Effect.provide(UserService.Default), Effect.runPromise)
+      }).pipe(runEffect)
     },
   },
 })

--- a/runtime/app-runtime.ts
+++ b/runtime/app-runtime.ts
@@ -1,0 +1,40 @@
+import { Layer, ManagedRuntime } from 'effect'
+import { CommitService } from '@/services/Commit'
+import { CommitSchemaService } from '@/services/CommitSchemaService'
+import { NextAuthService } from '@/services/NextAuth'
+import { UserService } from '@/services/User'
+
+/**
+ * 앱이 쓰는 서비스 전체. 서비스가 늘면 여기에만 추가하고, 호출부에서는
+ * 다시 provide 하지 않는다.
+ *
+ * 함수로 감싼 이유는 순환 참조 때문이다. `lib/auth.ts` 가 NextAuthService 를
+ * 거쳐 이 모듈로 돌아오므로, 모듈 평가 중에 서비스 클래스를 읽으면 아직
+ * 초기화되지 않은 바인딩에 닿는다.
+ */
+const makeAppLayer = () =>
+  Layer.mergeAll(
+    CommitService.Default,
+    CommitSchemaService.Default,
+    NextAuthService.Default,
+    UserService.Default
+  )
+
+export type AppServices = Layer.Layer.Success<ReturnType<typeof makeAppLayer>>
+
+const makeAppRuntime = () => ManagedRuntime.make(makeAppLayer())
+
+type AppRuntime = ReturnType<typeof makeAppRuntime>
+
+const globalForRuntime = globalThis as typeof globalThis & {
+  __macoRuntime?: AppRuntime
+}
+
+/**
+ * Layer 를 한 번만 만들어 요청 사이에 재사용한다. 호출부마다 provide 하면
+ * libsql 클라이언트와 Drizzle 계층이 매번 새로 만들어진다.
+ *
+ * 개발 모드의 HMR 은 모듈을 다시 평가하므로 globalThis 에 매달아 둔다.
+ */
+export const getAppRuntime = () =>
+  (globalForRuntime.__macoRuntime ??= makeAppRuntime())

--- a/runtime/render.tsx
+++ b/runtime/render.tsx
@@ -1,0 +1,70 @@
+import { ReactNode } from 'react'
+import { unstable_rethrow } from 'next/navigation'
+import { Cause, Effect, Exit, Option } from 'effect'
+import { AppServices, getAppRuntime } from './app-runtime'
+
+/**
+ * 로그인 전이거나 없는 메모를 열었을 때처럼 예상된 실패. ERROR 로 남기면
+ * 진짜 오류가 묻힌다.
+ */
+const EXPECTED_TAGS = new Set([
+  'NotFoundError',
+  'SessionError',
+  'SessionUserIdError',
+])
+
+const isExpected = (cause: Cause.Cause<unknown>) =>
+  Cause.failureOption(cause).pipe(
+    Option.exists(
+      (error) =>
+        typeof error === 'object' &&
+        error !== null &&
+        '_tag' in error &&
+        typeof error._tag === 'string' &&
+        EXPECTED_TAGS.has(error._tag)
+    )
+  )
+
+const logCause = (cause: Cause.Cause<unknown>) =>
+  isExpected(cause) ? Effect.logDebug(cause) : Effect.logError(cause)
+
+const DEFAULT_FALLBACK = (
+  <p className="p-4 text-gray-400">요청을 처리하지 못했습니다.</p>
+)
+
+/**
+ * notFound, redirect 는 Next 가 예외로 흘려보내는 제어 흐름이다. 우리가 대신
+ * 처리하면 해당 UI 가 렌더되지 않으므로 그대로 다시 던진다. Effect 가 감싼
+ * 경우가 있어 cause 사슬도 함께 확인한다.
+ */
+function rethrowFrameworkError(error: unknown) {
+  unstable_rethrow(error)
+
+  if (error instanceof Error && error.cause !== undefined) {
+    rethrowFrameworkError(error.cause)
+  }
+}
+
+/**
+ * 서버 컴포넌트가 Effect 를 실행하는 유일한 경계.
+ *
+ * 성공값만 JSX 로 옮기면 되고, 실패와 결함은 서버 로그로 보낸 뒤 화면에는
+ * 대체 UI 만 남긴다. 에러 내용을 화면이나 DOM 속성으로 흘리지 않는다.
+ */
+export async function renderEffect<A, E>(
+  effect: Effect.Effect<A, E, AppServices>,
+  onSuccess: (value: A) => ReactNode,
+  fallback: ReactNode = DEFAULT_FALLBACK
+): Promise<ReactNode> {
+  const exit = await getAppRuntime().runPromiseExit(
+    effect.pipe(Effect.map(onSuccess), Effect.tapErrorCause(logCause))
+  )
+
+  if (Exit.isSuccess(exit)) {
+    return exit.value
+  }
+
+  rethrowFrameworkError(Cause.squash(exit.cause))
+
+  return fallback
+}

--- a/runtime/run.ts
+++ b/runtime/run.ts
@@ -1,0 +1,7 @@
+import { Effect } from 'effect'
+import { AppServices, getAppRuntime } from './app-runtime'
+
+/** 서버 액션과 콜백에서 Effect 를 실행하는 지점. */
+export function runEffect<A, E>(effect: Effect.Effect<A, E, AppServices>) {
+  return getAppRuntime().runPromise(effect)
+}

--- a/services/NextAuth.ts
+++ b/services/NextAuth.ts
@@ -1,4 +1,4 @@
-import { auth, signIn } from '@/lib/auth'
+import { auth } from '@/lib/auth'
 import { Data, Effect, Option, pipe } from 'effect'
 
 export class NextAuthError extends Data.TaggedError('NextAuthError')<{
@@ -67,30 +67,6 @@ export class NextAuthService extends Effect.Service<NextAuthService>()(
             )
 
             return id
-          }),
-      }
-    }),
-  }
-) {}
-
-export class NextAuthSignService extends Effect.Service<NextAuthSignService>()(
-  'NextAuthSignService',
-  {
-    effect: Effect.gen(function* () {
-      return {
-        signIn: () =>
-          Effect.tryPromise({
-            try: () =>
-              signIn('github', {
-                redirectTo: '/',
-              }).catch((e) => {
-                throw e
-              }),
-            catch: (e) =>
-              new NextAuthError({
-                cause: e,
-                message: '로그인에러가 발생했습니다.',
-              }),
           }),
       }
     }),


### PR DESCRIPTION
omoji 에 적용한 개선을 같은 방향으로 옮겨왔다. Layer 는 한 곳에서만 만들고,
렌더 경계와 입력 검증을 각각 한 군데로 모은다.

## 앱 런타임 하나 (`runtime/`)

호출부 열두 곳이 각자 `Effect.provide` 를 하고 있었다. 그때마다 libsql
클라이언트와 Drizzle 계층이 새로 만들어진다. 인증 세션 콜백은 매 요청
도는 경로라 특히 손해다. `ManagedRuntime` 하나를 만들어 재사용한다.

`lib/auth.ts` 가 NextAuthService 를 거쳐 런타임 모듈로 돌아오는 순환 참조가
있어 Layer 와 런타임 모두 지연 생성한다. 모듈 평가 중에 서비스 클래스를
읽으면 초기화 순서에 걸린다.

서버 컴포넌트가 Effect 를 실행하는 지점은 `renderEffect` 하나다. 호출부는
성공값을 JSX 로 옮기는 함수와 대체 UI 만 넘긴다. 실패는 서버 로그로 가고,
예상된 실패(로그인 전 세션 없음, 없는 메모)는 DEBUG, 나머지는 ERROR 로
갈라 기록한다. 세션 오류를 `data-error` 속성에 JSON 으로 직렬화해 DOM 에
흘리던 코드도 없앴다. `notFound` 나 `redirect` 같은 프레임워크 제어 흐름
예외는 다시 던진다.

## 계정 수정 권한 문제

`updateUser` 가 폼의 hidden `id` 를 그대로 대상으로 삼고 있었다. 값을 바꿔
보내면 남의 계정 이름을 고칠 수 있다. 대상은 세션에서 가져온다.
`CLAUDE.md` 에 적어 둔 원칙(페이로드의 사용자 식별자를 믿지 않는다)이
쓰기 경로에는 지켜져 있었는데 이 액션만 빠져 있었다.

실패를 조용히 삼켜 저장된 것처럼 보이던 것도 고쳤다. 오류는 폼에 돌려준다.

## 잘못된 주소는 404

UUID 가 아닌 메모 주소에 `잘못된 주소입니다` 를 200 으로 내려주고 있었다.
세 화면이 같은 검사를 각자 복사해 두기도 했다. 한 곳으로 모으고
`notFound()` 로 보낸다. 이 앱은 PPR 을 쓰지 않아 상태 코드도 404 로 나간다.

## 확인

- `tsc --noEmit`, `eslint`, `next build` 통과
- 라우트 표가 변경 전과 동일한 것을 확인 (설정값 없이 빌드하면 Layer 구성이
  실패해 `/commit` 이 정적으로 잡히므로, 더미 설정값을 넣고 비교)
- 로컬 sqlite 로 마이그레이션 후 `next start` 로 홈, 새 메모, 스레드, 수정,
  이력, 잘못된 주소를 요청해 확인. 잘못된 주소만 404, 나머지 200,
  DOM 에 오류 노출 없음, 서버 로그에 ERROR 없음

사용하지 않던 `NextAuthSignService` 도 지웠다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3eZAadaLPJRgVZjr4QYsd
